### PR TITLE
fix: title on home page has '|' mark

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -6,6 +6,8 @@ import Navbar from './Navbar';
 
 export default function Layout(props: PageProps): JSX.Element {
   const {links, pages, pageName} = props;
+  const postTitle = pageName === '' ? '' : ` | ${pageName}`;
+
   const[hover, setHover] = useState(-1);
   function embedURL(stringUrl:string) : string{
     const url = new URL(stringUrl);
@@ -19,7 +21,7 @@ export default function Layout(props: PageProps): JSX.Element {
   return (
     <div style={{display: 'flex', justifyContent: 'center'}}>
       <Head>
-        <title>tinycl | {pageName}</title>
+        <title>tinycl{postTitle}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <Navbar pages={pages} pageName={pageName}/>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -15,7 +15,8 @@ export const getStaticProps: GetStaticProps = async () => {
   const data = await fetchContentful(pageQuery);
   const pages = data?.pageCollection?.items.map(({pageName}) => pageName);
   const page = data.pageCollection.items.find(({pageName}) => pageName === 'home');
-  return { props: {
+  return {props: {
+    pageName: '',
     links: page?.linksCollection?.items,
     pages,
   }};


### PR DESCRIPTION
Fix bug with home page is currently `tinycl |` to be `tinycl`