### PR TITLE
integration to membership portal

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ export default function Home(): JSX.Element {
 
   useEffect(() => {
     // Initial data fetch on mount
-    fetchLinks().then(setLinks);
+    void fetchLinks().then(setLinks);
 
     // Subscribe to any INSERT, UPDATE, or DELETE on the links table
     const channel = supabase
@@ -18,13 +18,13 @@ export default function Home(): JSX.Element {
         { event: '*', schema: 'public', table: 'links' },
         () => {
           // Re-fetch all links to stay in sync with the latest state
-          fetchLinks().then(setLinks);
-        }
+          void fetchLinks().then(setLinks);
+        },
       )
       .subscribe();
 
     return () => {
-      supabase.removeChannel(channel);
+      void supabase.removeChannel(channel);
     };
   }, []);
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,21 +1,32 @@
-import { GetStaticProps } from 'next';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import Layout from '../components/Layout';
-import { fetchLinks, PageProps } from '../utils';
+import { fetchLinks, Link } from '../utils';
+import { supabase } from '../utils/supabase';
 
-export default function Home({ pageName, links, pages }: PageProps): JSX.Element {
-  return (
-    <Layout pageName={pageName} links={links} pages={pages} />
-  );
+export default function Home(): JSX.Element {
+  const [links, setLinks] = useState<Link[]>([]);
+
+  useEffect(() => {
+    // Initial data fetch on mount
+    fetchLinks().then(setLinks);
+
+    // Subscribe to any INSERT, UPDATE, or DELETE on the links table
+    const channel = supabase
+      .channel('links-realtime')
+      .on(
+        'postgres_changes',
+        { event: '*', schema: 'public', table: 'links' },
+        () => {
+          // Re-fetch all links to stay in sync with the latest state
+          fetchLinks().then(setLinks);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, []);
+
+  return <Layout pageName="" links={links} pages={[]} />;
 }
-
-export const getStaticProps: GetStaticProps = async () => {
-  const links = await fetchLinks();
-  return {
-    props: {
-      pageName: '',
-      links,
-      pages: [],
-    },
-  };
-};

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -29,5 +29,5 @@ export async function fetchLinks(): Promise<Link[]> {
     displayName: row.display_name,
     url: row.url,
     redirect_path: row.redirect_path,
-  }));
+  })).reverse();
 }


### PR DESCRIPTION
Integrating the membership portal into tinyCL by removing getStaticProps (static build-time fetch) and adding client-side useEffect to fetch links on mount.

Every time someone makes a change to the links table through the membership internal page, tinyCL now uses Supabase Realtime postgres_changes on the links table and handles INSERT, UPDATE, DELETE events to update local state. 

Note: I don't know how the the midpoint check in zoom on there right now was added without making a supabase row, but you can add it to this version using the internal page and it should update on the tinyCL right away. 

